### PR TITLE
fix dashboard

### DIFF
--- a/dashboard/stage_data.R
+++ b/dashboard/stage_data.R
@@ -1,4 +1,3 @@
-options("duckdbfs_use_nightly"=TRUE) #temporary duckdb issue: https://github.com/duckdb/duckdb-r/issues/600
 
 
 library(dplyr)


### PR DESCRIPTION
@rqthomas I don't think this is required anymore.  

For a while we had to use nightly, now nightly is broken and we have to use latest.  I patched duckdbfs twice on this, though the hard-override left here requesting nightly is keeping it broken I think.  