### PR TITLE
Fix three failing CI jobs: bundling ABI, ticks dates, dashboard timeouts

### DIFF
--- a/.github/workflows/bundling.yaml
+++ b/.github/workflows/bundling.yaml
@@ -23,7 +23,10 @@ jobs:
       - name: Install
         shell: Rscript {0}
         run: |
-          options(repos=list(CRAN="http://packagemanager.rstudio.com/all/__linux__/noble/latest"))
+          # Pin to a dated PPM snapshot so binary packages match the container's R ABI.
+          # `latest` began serving binaries built for a newer R on 2026-06-22, which
+          # pulled in an rlang built against that newer R (undefined symbol: SETLENGTH).
+          options(repos=list(CRAN="http://packagemanager.rstudio.com/all/__linux__/noble/2026-06-21"))
           install.packages(c("future.apply", "progressr", "minioclient", "bench", "glue", "fs"))
 
 

--- a/dashboard/stage_data.R
+++ b/dashboard/stage_data.R
@@ -2,6 +2,20 @@ library(dplyr)
 library(duckdbfs)
 library(lubridate)
 
+# OSN (sdsc.osn.xsede.org) intermittently times out / throttles on the large
+# bundled-parquet listings. Extend the httpfs timeout and add retries so a slow
+# response doesn't abort the whole render.
+local({
+  con <- duckdbfs::cached_connection()
+  try(DBI::dbExecute(con, "INSTALL httpfs; LOAD httpfs;"), silent = TRUE)
+  for (s in c("SET http_timeout=600000",     # 10 min (ms), default 30s
+              "SET http_retries=5",           # default 3
+              "SET http_retry_wait_ms=500",
+              "SET http_keep_alive=true")) {
+    try(DBI::dbExecute(con, s), silent = TRUE)
+  }
+})
+
 config <- yaml::read_yaml("challenge_configuration.yaml")
 sites <- open_dataset(config$catalog_config$site_metadata_url) |>
   rename(site_id = field_site_id)

--- a/targets/ticks_targets.R
+++ b/targets/ticks_targets.R
@@ -122,7 +122,8 @@ tick_standard <- tick_long %>%
   filter(siteID %in% target_sites, # sites we want
          lifeStage == target_lifestage, # life stage we want
          scientificName %in% target_species,
-         grepl("Forest", nlcdClass)) %>%  # forest plots
+         grepl("Forest", nlcdClass), # forest plots
+         !is.na(collectDate)) %>%  # drop rows w/ unparseable dates (provisional data schema gaps)
   mutate(date = floor_date(collectDate, unit = "day"),
          date = ymd(date),
          year = year(date),


### PR DESCRIPTION
Three scheduled workflows have been failing with distinct root causes. This PR resolves all three.

## 1. `bundling` — R ABI break (failing every 6h since 2026-06-22 14:00)
The job died loading `tidyverse` with `rlang.so: undefined symbol: SETLENGTH`. Around 06-22, PPM `__linux__/noble/latest` began serving package binaries built against a newer R than the pinned `ghcr.io/boettiger-lab/k8s` image ships, pulling in an incompatible `rlang`. Nothing in the repo changed — the external package repo drifted.

**Fix:** pin the install repo to the `noble/2026-06-21` snapshot (last green run used `latest` at 06-22 08:16). Longer-term alternative is rebuilding/repinning the k8s image so its R matches `latest`.

## 2. `target-generation` (ticks) — unparseable dates (daily, last 3 runs)
NEON's provisional-data schema lookup failed, so `tck_fielddata` fields came back as strings; some `collectDate` values don't parse → `NA` ISO-weeks → `ISOweek::ISOweek2date("NA-1")` throws "All formats failed to parse".

**Fix:** drop rows with `NA` `collectDate` before the ISO-week conversion. Defensive against upstream NEON provisional flakiness.

## 3. `dashboard` — OSN timeouts (recurring ~1 week)
Repeated `IO Error: Timeout was reached` on HTTP GET/LIST against `sdsc.osn.xsede.org/.../bundled-parquet/...` — OSN slowness/throttling, not a code bug.

**Fix:** raise duckdb httpfs `http_timeout` (→10 min) and `http_retries` (→5) on the connection so slow listings retry instead of aborting the render. Settings verified locally.

Note: the dashboard reads the bundled-parquet that the (broken) bundling job maintains, so fixing bundling should also help the dashboard recover.