### PR TITLE
bundling: use rocker-neon4cast image, stop live package installs

### DIFF
--- a/.github/workflows/bundling.yaml
+++ b/.github/workflows/bundling.yaml
@@ -14,21 +14,9 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       OSN_KEY: ${{ secrets.OSN_KEY }}
       OSN_SECRET: ${{ secrets.OSN_SECRET }}
-    container:
-      image: ghcr.io/boettiger-lab/k8s@sha256:fd02edfb4318afe022f8a732a99d93df7127dadb2bb4e208e36a86f96c2f45c6
-      options: --user root
+    container: eco4cast/rocker-neon4cast:latest
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install
-        shell: Rscript {0}
-        run: |
-          # Pin to a dated PPM snapshot so binary packages match the container's R ABI.
-          # `latest` began serving binaries built for a newer R on 2026-06-22, which
-          # pulled in an rlang built against that newer R (undefined symbol: SETLENGTH).
-          options(repos=list(CRAN="http://packagemanager.rstudio.com/all/__linux__/noble/2026-06-21"))
-          install.packages(c("future.apply", "progressr", "minioclient", "bench", "glue", "fs"))
-
 
       - name: Bundle forecasts
         run: r submission_processing/bundled_forecasts.R

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN install2.r devtools remotes reticulate neonstore RCurl neonUtilities content
 
 RUN install2.r renv rjags ISOweek RNetCDF fable fabletools forecast imputeTS duckdbfs gsheet patchwork pak ggiraph
 
-RUN install2.r ncdf4 scoringRules tidybayes tidync udunits2 bench yaml here feasts future furrr jsonlite bsicons bslib neonUtilities
+RUN install2.r ncdf4 scoringRules tidybayes tidync udunits2 bench yaml here feasts future furrr jsonlite bsicons bslib neonUtilities future.apply progressr
 
 RUN R -e "remotes::install_github('eco4cast/stac4cast')"
 RUN sleep 180
@@ -28,3 +28,5 @@ RUN R -e "remotes::install_github('eco4cast/gefs4cast', upgrade = FALSE)"
 RUN sleep 180
 RUN R -e "remotes::install_github('mitchelloharawild/distributional', ref = 'bb0427e')"
 RUN R -e "remotes::install_version('arrow', version = '20.0.0')"
+# dev duckdbfs (bundling scripts previously installed this live at runtime)
+RUN R -e "remotes::install_github('cboettig/duckdbfs', upgrade = FALSE)"

--- a/submission_processing/bundled_forecasts.R
+++ b/submission_processing/bundled_forecasts.R
@@ -1,5 +1,3 @@
-remotes::install_github("cboettig/duckdbfs", upgrade=FALSE)
-
 library(tidyverse)
 library(duckdbfs)
 library(minioclient)

--- a/submission_processing/bundled_summaries.R
+++ b/submission_processing/bundled_summaries.R
@@ -1,5 +1,3 @@
-remotes::install_github("cboettig/duckdbfs", upgrade=FALSE)
-
 library(tidyverse)
 library(duckdbfs)
 library(minioclient)


### PR DESCRIPTION
## Problem
`bundling` was the only job pinned to a **foreign** image — `ghcr.io/boettiger-lab/k8s@sha256:fd02…` — rather than our own `eco4cast/rocker-neon4cast:latest`. That image is `bspm/r2u`-based, so the job's runtime `install.packages()` / `install_github()` calls shelled out to `apt` and **upgraded `r-base-core` 4.5 → 4.6 inside the container**. R 4.6 changed the C ABI, so the image's pre-baked (R-4.5-compiled) packages failed to load:

```
rlang.so / vctrs.so: undefined symbol: SETLENGTH
```

Pinning the image by digest but then mutating R inside it at runtime defeated the point of pinning. This is why bundling has failed every 6h since 2026-06-22.

## Fix
- Point `bundling` at `eco4cast/rocker-neon4cast:latest`, the same rocker-based image every other job uses (built daily from this repo's Dockerfile as a coherent, ABI-consistent whole).
- Remove **all** runtime installs from the workflow and from `bundled_forecasts.R` / `bundled_summaries.R`.
- Bake the only three deps the bundling scripts needed that the image lacked into the Dockerfile: `future.apply`, `progressr`, and the dev `cboettig/duckdbfs`.

After this, bundling does only `checkout` + run — it relies on the image as intended, no live package mutation.

## Sequencing note
The Dockerfile change triggers the `docker container` build (push → main, `paths: Dockerfile`). The new image must finish building/publishing before the next bundling run picks up `future.apply`/`progressr`/dev-`duckdbfs`.