### PR TITLE
ticks: robustly parse collectDate (provisional-data date failures)

### DIFF
--- a/targets/ticks_targets.R
+++ b/targets/ticks_targets.R
@@ -71,7 +71,8 @@ tick_taxon_raw <- datasetQuery(dpID="DP1.10093.001",
 # so, keep records when sampling occurred
 tick_field <- tick_field_raw %>%
   filter(totalSampledArea > 0) %>%
-  mutate(collectDate = lubridate::as_datetime(collectDate),
+  mutate(collectDate = lubridate::ymd_hms(as.character(collectDate),
+                                          truncated = 3, quiet = TRUE),
          time = floor_date(collectDate, unit = "day")) %>%
   unite(namedLocation, time, col = "occasionID", sep = "_")
 


### PR DESCRIPTION
## Problem
The `ticks` target-generation job still fails after #14's NA guard:
```
Caused by error in `ISOweek::ISOweek2date()`:
! all(is.na(weekdate) | stringr::str_detect(weekdate, kPattern)) is not TRUE
ℹ In argument: `collectDate = lubridate::as_datetime(collectDate)`.
! All formats failed to parse. No formats found.
```
With `include.provisional = TRUE`, NEON's variables-file schema lookup fails, so `tck_fielddata`/`tck_taxonomyProcessed` columns come back as **strings**. `lubridate::as_datetime()` can't guess a format for them and errors, and the malformed (non-`NA`) ISO-weeks that result slip past the `!is.na()` filter and crash `ISOweek2date()`.

## Fix
Parse `collectDate` with `lubridate::ymd_hms(as.character(collectDate), truncated = 3, quiet = TRUE)` at both parse points. Verified locally it handles:
- `2024-06-10T13:35:00Z` and `2024-06-10T13:35Z`
- `2024-06-10` (date-only)
- `2024-06-10 13:35:00` (already-datetime → character)
- empty / `NA` / garbage → `NA`

`NA` rows are then dropped by the existing `!is.na(collectDate)` filter, so only valid dates reach `ISOweek2date()`. Keeps provisional data (no loss of recent observations).