### PR TITLE
submissions: stop live package installs, rely on baked image

### DIFF
--- a/.github/workflows/submissions.yaml
+++ b/.github/workflows/submissions.yaml
@@ -25,9 +25,4 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Process submissions
-        shell: Rscript {0}
-        run: |
-          remotes::install_github("cboettig/duckdbfs", upgrade="never")
-          remotes::install_github("eco4cast/neon4cast")          
-          remotes::install_github("eco4cast/score4cast")
-          source("submission_processing/process_submissions.R")
+        run: r submission_processing/process_submissions.R


### PR DESCRIPTION
## Problem

`process-submissions` has been failing intermittently (roughly half of the 2-hourly runs). The failing runs all die at the same place:

```
Error: Failed to install 'score4cast' from GitHub:
  HTTP error 429.
  This endpoint is temporarily being throttled. Please try again later.
```

The `Process submissions` step ran `remotes::install_github()` for `duckdbfs`, `neon4cast`, and `score4cast` on every run. These calls hit the GitHub API and intermittently get throttled (429), failing the whole job.

## Fix

All three packages are already baked into `eco4cast/rocker-neon4cast:latest` (see `Dockerfile`: `cboettig/duckdbfs`, `eco4cast/neon4cast`, `eco4cast/score4cast`), so the runtime installs are redundant. Remove them and run the script directly with `r submission_processing/process_submissions.R`.

This mirrors the bundling job fix in f1c67c282 ("use rocker-neon4cast image, stop live package installs").

All `library()` calls in `process_submissions.R` resolve to packages present in the image; `install_mc()` only downloads the mc binary and is unaffected.