### PR TITLE
Retarget self-hosted jobs to the efi-cirrus runner label

### DIFF
--- a/.github/workflows/drivers_stage3.yaml
+++ b/.github/workflows/drivers_stage3.yaml
@@ -7,7 +7,7 @@ name: drivers-stage3
 
 jobs:
   docker:
-    runs-on: arc-runner-eco4cast
+    runs-on: efi-cirrus
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       OSN_KEY: ${{ secrets.OSN_KEY }}

--- a/.github/workflows/scoring.yaml
+++ b/.github/workflows/scoring.yaml
@@ -9,7 +9,7 @@ name: scoring
 
 jobs:
   scoring:
-    runs-on: arc-runner-eco4cast
+    runs-on: efi-cirrus
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       OSN_KEY: ${{ secrets.OSN_KEY }}

--- a/.github/workflows/targets.yaml
+++ b/.github/workflows/targets.yaml
@@ -33,7 +33,7 @@ jobs:
           source("targets/phenology_targets.R")
 
   terrestrial:
-    runs-on: arc-runner-eco4cast
+    runs-on: efi-cirrus
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_SUBMISSIONS }}


### PR DESCRIPTION
Consolidates the two redundant eco4cast self-hosted runner scale sets on the
cirrus cluster into one.

`arc-runner-eco4cast` and `efi-cirrus` are both org-level scale sets pointing at
the same runner group on the same machine, differing only in which repo calls
them: this repo used `arc-runner-eco4cast`, while eco4cast/usgsrc4cast-ci used
`efi-cirrus`. Keeping two adds no capacity and doubles the maintenance surface
(two secrets to rotate, two Helm releases). This retargets the three jobs here
onto `efi-cirrus`, after which `arc-runner-eco4cast` will be uninstalled.

Changes are one line each in `scoring.yaml`, `drivers_stage3.yaml`, and
`targets.yaml` — no other edits.

Capacity is unchanged. `efi-cirrus` is being raised from `maxRunners: 1` to
`maxRunners: 2` on the cluster side, so the two jobs that both fire at 23:00 UTC
(this repo's `drivers_stage3` and usgsrc4cast-ci's `drivers_stage1`) still run
concurrently rather than serializing.

**Do not merge until the cirrus runner is confirmed healthy.** These runners have
been down since 2026-07-19 on an expired GitHub PAT — every scheduled run since
has been cancelled or left queued. Once the credential is restored and
`efi-cirrus` picks up a job, this is safe to merge.